### PR TITLE
fix: TypeError "unhashable type: "EncryptedDataKey"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         'boto3>=1.4.4',
         'cryptography>=1.4.0',
-        'attrs>=16.3.0'
+        'attrs==16.3.0'
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
When attrs package update to version 17 some things may have broken.
In my case i got an exception in python set object when you try to add a new element to the list and the object is not hashable

internal/utils.py line 174 raise TypeError
encrypted_data_keys.add(encrypted_key)