### PR TITLE
refactoring Algorithm definition components into separate encryption, kdf, and authentication algorithm suites

### DIFF
--- a/src/aws_encryption_sdk/identifiers.py
+++ b/src/aws_encryption_sdk/identifiers.py
@@ -173,7 +173,7 @@ class AlgorithmSuite(Enum):  # pylint: disable=too-many-instance-attributes
         self.authentication = authentication
         self.allowed = allowed
 
-        # Encryption Suite Legacy Compatibility
+        # Encryption Values
         self.encryption_algorithm = self.encryption.algorithm
         self.encryption_mode = self.encryption.mode
         self.data_key_len = self.encryption.data_key_length
@@ -181,11 +181,11 @@ class AlgorithmSuite(Enum):  # pylint: disable=too-many-instance-attributes
         self.auth_key_len = self.encryption.auth_key_length
         self.auth_len = self.tag_len = self.encryption.auth_length
 
-        # KDF Suite Legacy Compatibility
+        # KDF Values
         self.kdf_type = self.kdf.algorithm
         self.kdf_hash_type = self.kdf.hash_algorithm
 
-        # Authentication Suite Legacy Compatibility
+        # Authentication Values
         self.signing_algorithm_info = self.authentication.algorithm
         self.signing_hash_type = self.authentication.hash_algorithm
         self.signature_len = self.authentication.signature_length

--- a/src/aws_encryption_sdk/identifiers.py
+++ b/src/aws_encryption_sdk/identifiers.py
@@ -135,6 +135,8 @@ class AuthenticationSuite(Enum):
 class AlgorithmSuite(Enum):  # pylint: disable=too-many-instance-attributes
     """Static combinations of encryption, KDF, and authentication algorithms.
 
+    .. warning:: No AlgorithmSuites except those defined here are supported.
+
     :param int algorithm_id: KMS Encryption Algorithm ID
     :param encryption_suite: EncryptionSuite to use with this AlgorithmSuite
     :type encryption_suite: aws_encryption_sdk.identifiers.EncryptionSuite

--- a/src/aws_encryption_sdk/identifiers.py
+++ b/src/aws_encryption_sdk/identifiers.py
@@ -28,6 +28,8 @@ USER_AGENT_SUFFIX = 'AwsEncryptionSdkPython-KMSMasterKey/{}'.format(__version__)
 class EncryptionSuite(Enum):
     """Static definition of encryption algorithm details.
 
+    .. warning:: These members must only be used as part of an AlgorithmSuite.
+
     :param algorithm: Encryption algorithm to use
     :type algorithm: cryptography.io ciphers algorithm object
     :param mode: Encryption mode in which to operate
@@ -73,6 +75,8 @@ class EncryptionSuite(Enum):
 class KDFSuite(Enum):
     """Static definition of key derivation algorithm details.
 
+    .. warning:: These members must only be used as part of an AlgorithmSuite.
+
     :param algorithm: KDF algorithm to use
     :type algorithm: cryptography.io KDF object
     :param int input_length: Number of bytes of input data to feed into KDF function
@@ -107,6 +111,8 @@ class KDFSuite(Enum):
 
 class AuthenticationSuite(Enum):
     """Static definition of authentication algorithm details.
+
+    .. warning:: These members must only be used as part of an AlgorithmSuite.
 
     :param algorithm: Information needed by signing algorithm to define behavior
     :type algorithm: may vary (currently only ECC curve object)


### PR DESCRIPTION
This is an idea I've been playing with to try and make the algorithm suites more comprehensible and less error-prone.

## Status Quo
Each algorithm suite is composed of a large number of individual values that together form the complete algorithm suite specification.

## Problem
These algorithm suite definitions are hard to understand, hard to debug, and easy to mess up.

## Solution
Algorithm suites are not conceptually a grouping of a large number of primitives. They are a grouping of a small number of groupings of related values. Each of these groupings define characteristics of the overall algorithm suite.

I have separated these out into three sub-suites:
1. Encryption : contains only those values that control the encryption behavior
1. KDF : contains only those values that control the key derivation behavior
1. Authentication : contains only those values that control the authentication behavior

Each algorithm suite is then defined as a combination of these three sub-suites.

This lets us move from each algorithm suites having 13 distinct characteristics with no innately relations to:
* Three distinct encryption suites
* Two distinct KDF suites
* Three distinct authentication suites

Each algorithm suite now has four important values: algorithm ID, encryption suite, KDF suite, and authentication suite.

For legacy compatibility, when each algorithm suite is constructed, it still sets all of its expected attributes using the attributes of the sub-suites.