### PR TITLE
updating attr to >=17.4.0 and changing all uses of attr.ib from deprecated "convert" to "converter"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto3>=1.4.4
 cryptography>=1.8.1
-attrs>=16.3.0
+attrs>=17.4.0
 wrapt>=1.10.11

--- a/src/aws_encryption_sdk/key_providers/base.py
+++ b/src/aws_encryption_sdk/key_providers/base.py
@@ -303,7 +303,7 @@ class MasterKeyConfig(object):
     key_id = attr.ib(
         hash=True,
         validator=attr.validators.instance_of((six.string_types, bytes)),
-        convert=to_bytes
+        converter=to_bytes
     )
 
     def __attrs_post_init__(self):

--- a/src/aws_encryption_sdk/key_providers/kms.py
+++ b/src/aws_encryption_sdk/key_providers/kms.py
@@ -52,13 +52,13 @@ class KMSMasterKeyProviderConfig(MasterKeyProviderConfig):
         hash=True,
         default=attr.Factory(tuple),
         validator=attr.validators.instance_of(tuple),
-        convert=tuple
+        converter=tuple
     )
     region_names = attr.ib(
         hash=True,
         default=attr.Factory(tuple),
         validator=attr.validators.instance_of(tuple),
-        convert=tuple
+        converter=tuple
     )
 
 
@@ -179,7 +179,7 @@ class KMSMasterKeyConfig(MasterKeyConfig):
         hash=True,
         default=attr.Factory(tuple),
         validator=attr.validators.instance_of(tuple),
-        convert=tuple
+        converter=tuple
     )
 
 

--- a/src/aws_encryption_sdk/key_providers/raw.py
+++ b/src/aws_encryption_sdk/key_providers/raw.py
@@ -43,7 +43,7 @@ class RawMasterKeyConfig(MasterKeyConfig):
     provider_id = attr.ib(
         hash=True,
         validator=attr.validators.instance_of((six.string_types, bytes)),
-        convert=aws_encryption_sdk.internal.str_ops.to_str
+        converter=aws_encryption_sdk.internal.str_ops.to_str
     )
     wrapping_key = attr.ib(hash=True, validator=attr.validators.instance_of(WrappingKey))
 

--- a/src/aws_encryption_sdk/materials_managers/caching.py
+++ b/src/aws_encryption_sdk/materials_managers/caching.py
@@ -89,7 +89,7 @@ class CachingCryptoMaterialsManager(CryptoMaterialsManager):
     )
     partition_name = attr.ib(
         default=None,
-        convert=to_bytes,
+        converter=to_bytes,
         validator=attr.validators.optional(attr.validators.instance_of(bytes))
     )
     master_key_provider = attr.ib(

--- a/src/aws_encryption_sdk/streaming_client.py
+++ b/src/aws_encryption_sdk/streaming_client.py
@@ -64,7 +64,7 @@ class _ClientConfig(object):
             will attempt to seek() to the end of the stream and tell() to find the length of source data.
     """
 
-    source = attr.ib(hash=True, convert=aws_encryption_sdk.internal.utils.prep_stream_data)
+    source = attr.ib(hash=True, converter=aws_encryption_sdk.internal.utils.prep_stream_data)
     materials_manager = attr.ib(
         hash=True,
         default=None,

--- a/src/aws_encryption_sdk/structures.py
+++ b/src/aws_encryption_sdk/structures.py
@@ -70,12 +70,12 @@ class MasterKeyInfo(object):
     provider_id = attr.ib(
         hash=True,
         validator=attr.validators.instance_of((six.string_types, bytes)),
-        convert=to_str
+        converter=to_str
     )
     key_info = attr.ib(
         hash=True,
         validator=attr.validators.instance_of((six.string_types, bytes)),
-        convert=to_bytes
+        converter=to_bytes
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,8 +34,7 @@ passenv =
 sitepackages = False
 deps =
     mock
-    pytest!=3.3.0
-    pytest-catchlog
+    pytest>=3.3.1
     pytest-cov
     pytest-mock
     coverage


### PR DESCRIPTION
* updating attr to >=17.4.0 and changing all uses of attr.ib from deprecated "convert" to "converter" #39 
* updating pytest to >=3.3.1 to move past #32