### PR TITLE
moving test selection to pytest markers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,37 @@ language: python
 matrix:
   include:
     - python: 2.7
-      env: TOXENV=py27
+      env: TOXENV=py27-local
+    - python: 2.7
+      env: TOXENV=py27-integ
+    - python: 2.7
+      env: TOXENV=py27-accept
+    - python: 2.7
+      env: TOXENV=py27-examples
     - python: 3.4
-      env: TOXENV=py34
+      env: TOXENV=py34-local
+    - python: 3.4
+      env: TOXENV=py34-integ
+    - python: 3.4
+      env: TOXENV=py34-accept
+    - python: 3.4
+      env: TOXENV=py34-examples
     - python: 3.5
-      env: TOXENV=py35
+      env: TOXENV=py35-local
+    - python: 3.5
+      env: TOXENV=py35-integ
+    - python: 3.5
+      env: TOXENV=py35-accept
+    - python: 3.5
+      env: TOXENV=py35-examples
     - python: 3.6
-      env: TOXENV=py36
+      env: TOXENV=py36-local
+    - python: 3.6
+      env: TOXENV=py36-integ
+    - python: 3.6
+      env: TOXENV=py36-accept
+    - python: 3.6
+      env: TOXENV=py36-examples
     - python: 3.6
       env: TOXENV=bandit
     - python: 3.6
@@ -27,8 +51,6 @@ matrix:
       env: TOXENV=flake8-tests
     - python: 3.6
       env: TOXENV=pylint-tests
-    - python: 3.6
-      env: TOXENV=examples
     - python: 3.6
       env: TOXENV=flake8-examples
     - python: 3.6

--- a/examples/test/test_i_basic_encryption.py
+++ b/examples/test/test_i_basic_encryption.py
@@ -22,10 +22,11 @@ import botocore.session
 import pytest
 
 from basic_encryption import cycle_string
-from integration_test_utils import get_cmk_arn, SKIP_MESSAGE, skip_tests
+from integration_test_utils import get_cmk_arn
+
+pytestmark = [pytest.mark.examples]
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_cycle_string():
     plaintext = os.urandom(1024)
     cmk_arn = get_cmk_arn()

--- a/examples/test/test_i_basic_file_encryption_with_multiple_providers.py
+++ b/examples/test/test_i_basic_file_encryption_with_multiple_providers.py
@@ -23,10 +23,11 @@ import botocore.session
 import pytest
 
 from basic_file_encryption_with_multiple_providers import cycle_file
-from integration_test_utils import get_cmk_arn, SKIP_MESSAGE, skip_tests
+from integration_test_utils import get_cmk_arn
+
+pytestmark = [pytest.mark.examples]
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_cycle_file():
     cmk_arn = get_cmk_arn()
     _handle, filename = tempfile.mkstemp()

--- a/examples/test/test_i_basic_file_encryption_with_raw_key_provider.py
+++ b/examples/test/test_i_basic_file_encryption_with_raw_key_provider.py
@@ -22,10 +22,10 @@ import tempfile
 import pytest
 
 from basic_file_encryption_with_raw_key_provider import cycle_file
-from integration_test_utils import SKIP_MESSAGE, skip_tests
+
+pytestmark = [pytest.mark.examples]
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_cycle_file():
     _handle, filename = tempfile.mkstemp()
     with open(filename, 'wb') as f:

--- a/examples/test/test_i_data_key_caching_basic.py
+++ b/examples/test/test_i_data_key_caching_basic.py
@@ -21,10 +21,11 @@ sys.path.extend([  # noqa
 import pytest
 
 from data_key_caching_basic import encrypt_with_caching
-from integration_test_utils import get_cmk_arn, SKIP_MESSAGE, skip_tests
+from integration_test_utils import get_cmk_arn
+
+pytestmark = [pytest.mark.examples]
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_encrypt_with_caching():
     cmk_arn = get_cmk_arn()
     encrypt_with_caching(

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,15 @@ branch = True
 [coverage:report]
 show_missing = True
 
+[tool:pytest]
+markers =
+    local: superset of unit and functional (does not require network access)
+    unit: mark test as a unit test (does not require network access)
+    functional: mark test as a functional test (does not require network access)
+    integ: mark a test as an integration test (requires network access)
+    accept: mark a test as an acceptance test (requires network access)
+    examples: mark a test as an examples test (requires network access)
+
 # Flake8 Configuration
 [flake8]
 max_complexity = 10

--- a/test/functional/test_f_aws_encryption_sdk_client.py
+++ b/test/functional/test_f_aws_encryption_sdk_client.py
@@ -34,6 +34,8 @@ from aws_encryption_sdk.key_providers.base import MasterKeyProviderConfig
 from aws_encryption_sdk.key_providers.raw import RawMasterKeyProvider
 from aws_encryption_sdk.materials_managers import DecryptionMaterialsRequest, EncryptionMaterialsRequest
 
+pytestmark = [pytest.mark.functional, pytest.mark.local]
+
 VALUES = {
     'frame_lengths': (  # Assuming 1280 byte plaintext:
         0,  # Non-framed
@@ -347,7 +349,10 @@ def test_encryption_cycle_raw_mkp(wrapping_algorithm, encryption_key_type, decry
     assert plaintext == VALUES['plaintext_128']
 
 
-@pytest.mark.skipif(not _mgf1_sha256_supported(), reason='MGF1-SHA256 not supported by this backend')
+@pytest.mark.skipif(
+    not _mgf1_sha256_supported(),
+    reason='MGF1-SHA256 not supported by this backend: OpenSSL required v1.0.2+'
+)
 @pytest.mark.parametrize('wrapping_algorithm, encryption_key_type, decryption_key_type', (
     (WrappingAlgorithm.RSA_OAEP_SHA256_MGF1, EncryptionKeyType.PRIVATE, EncryptionKeyType.PRIVATE),
     (WrappingAlgorithm.RSA_OAEP_SHA256_MGF1, EncryptionKeyType.PUBLIC, EncryptionKeyType.PRIVATE)

--- a/test/functional/test_f_crypto.py
+++ b/test/functional/test_f_crypto.py
@@ -20,6 +20,8 @@ import aws_encryption_sdk
 from aws_encryption_sdk.internal.crypto.authentication import Signer
 from aws_encryption_sdk.internal.crypto.elliptic_curve import _ecc_static_length_signature
 
+pytestmark = [pytest.mark.functional, pytest.mark.local]
+
 
 # Run several of each type to make get a high probability of forcing signature length correction
 @pytest.mark.parametrize('algorithm', [

--- a/test/functional/test_f_crypto_iv.py
+++ b/test/functional/test_f_crypto_iv.py
@@ -17,6 +17,8 @@ from aws_encryption_sdk.exceptions import ActionNotAllowedError
 from aws_encryption_sdk.internal.crypto.iv import frame_iv, header_auth_iv, non_framed_body_iv
 from aws_encryption_sdk.internal.defaults import ALGORITHM, MAX_FRAME_COUNT
 
+pytestmark = [pytest.mark.functional, pytest.mark.local]
+
 VALUES = {
     'ivs': {
         'header_auth': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',

--- a/test/functional/test_f_xcompat.py
+++ b/test/functional/test_f_xcompat.py
@@ -29,6 +29,8 @@ from aws_encryption_sdk.internal.crypto.wrapping_keys import WrappingKey
 from aws_encryption_sdk.internal.str_ops import to_bytes
 from aws_encryption_sdk.key_providers.raw import RawMasterKeyProvider
 
+pytestmark = [pytest.mark.accept]
+
 
 # Environment-specific test file locator.  May not always exist.
 def _file_root():

--- a/test/integration/README.rst
+++ b/test/integration/README.rst
@@ -7,7 +7,6 @@ In order to run these integration tests successfully, these things must be confi
 #. Ensure that AWS credentials are available in one of the `automatically discoverable credential locations`_.
 #. Set environment variable ``AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID`` to valid
    `AWS KMS key id`_ to use for integration tests.
-#. Set environment variable ``AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_CONTROL`` to ``RUN``.
 
 .. _automatically discoverable credential locations: http://boto3.readthedocs.io/en/latest/guide/configuration.html
 .. _AWS KMS key id: http://docs.aws.amazon.com/kms/latest/APIReference/API_Encrypt.html

--- a/test/integration/integration_test_utils.py
+++ b/test/integration/integration_test_utils.py
@@ -10,30 +10,26 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-"""Utility functions to handle configuration, credentials setup, and test skip
-decision making for integration tests."""
+"""Utility functions to handle configuration and credentials setup for integration tests."""
 import os
 
 from aws_encryption_sdk.key_providers.kms import KMSMasterKeyProvider
 
-SKIP_MESSAGE = (
-    'Required environment variables not found. Skipping integration tests.'
-    ' See integration tests README.rst for more information.'
-)
-TEST_CONTROL = 'AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_CONTROL'
 AWS_KMS_KEY_ID = 'AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID'
-
-
-def skip_tests():
-    """Only run tests if both required environment variables are found."""
-    test_control = os.environ.get(TEST_CONTROL, None)
-    key_id = os.environ.get(AWS_KMS_KEY_ID, None)
-    return not (test_control == 'RUN' and key_id is not None)
 
 
 def get_cmk_arn():
     """Retrieves the target CMK ARN from environment variable."""
-    return os.environ.get(AWS_KMS_KEY_ID)
+    arn = os.environ.get(AWS_KMS_KEY_ID, None)
+    if arn is None:
+        raise ValueError(
+            'Environment variable "{}" must be set to a valid KMS CMK ARN for integration tests to run'.format(
+                AWS_KMS_KEY_ID
+            )
+        )
+    if arn.startswith('arn:') and ':alias/' not in arn:
+        return arn
+    raise ValueError('KMS CMK ARN provided for integration tests much be a key not an alias')
 
 
 def setup_kms_master_key_provider():

--- a/test/integration/test_i_aws_encrytion_sdk_client.py
+++ b/test/integration/test_i_aws_encrytion_sdk_client.py
@@ -14,9 +14,13 @@
 import io
 import unittest
 
+import pytest
+
 import aws_encryption_sdk
 from aws_encryption_sdk.identifiers import Algorithm
-from .integration_test_utils import setup_kms_master_key_provider, SKIP_MESSAGE, skip_tests
+from .integration_test_utils import setup_kms_master_key_provider
+
+pytestmark = [pytest.mark.integ]
 
 
 VALUES = {
@@ -39,8 +43,6 @@ VALUES = {
 class TestKMSThickClientIntegration(unittest.TestCase):
 
     def setUp(self):
-        if skip_tests():
-            self.skipTest(SKIP_MESSAGE)
         self.kms_master_key_provider = setup_kms_master_key_provider()
 
     def test_encryption_cycle_default_algorithm_framed_stream(self):

--- a/test/integration/test_i_thread_safety.py
+++ b/test/integration/test_i_thread_safety.py
@@ -22,7 +22,9 @@ import pytest
 from six.moves import queue  # six.moves confuses pylint: disable=import-error
 
 import aws_encryption_sdk
-from .integration_test_utils import setup_kms_master_key_provider, SKIP_MESSAGE, skip_tests
+from .integration_test_utils import setup_kms_master_key_provider
+
+pytestmark = [pytest.mark.integ]
 
 
 PLAINTEXT = (
@@ -101,7 +103,6 @@ def random_pause_time(max_seconds=3):
     return SystemRandom().random() * 10 % max_seconds
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_threading_loop():
     """Test thread safety of client."""
     rounds = 20
@@ -127,7 +128,6 @@ def test_threading_loop():
     assert all(value == PLAINTEXT for value in decrypted_values)
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 def test_threading_loop_with_common_cache():
     """Test thread safety of client while using common cryptographic materials cache across all threads."""
     rounds = 20

--- a/test/integration/test_i_xcompat_kms.py
+++ b/test/integration/test_i_xcompat_kms.py
@@ -17,7 +17,9 @@ import os
 import pytest
 
 import aws_encryption_sdk
-from .integration_test_utils import setup_kms_master_key_provider, SKIP_MESSAGE, skip_tests
+from .integration_test_utils import setup_kms_master_key_provider
+
+pytestmark = [pytest.mark.accept]
 
 
 # Environment-specific test file locator.  May not always exist.
@@ -32,9 +34,6 @@ except ImportError:
 
 
 def _generate_test_cases():
-    if skip_tests():
-        return []
-
     kms_key_provider = setup_kms_master_key_provider()
     try:
         root_dir = os.path.abspath(file_root())
@@ -73,7 +72,6 @@ def _generate_test_cases():
     return _test_cases
 
 
-@pytest.mark.skipif(skip_tests(), reason=SKIP_MESSAGE)
 @pytest.mark.parametrize('plaintext_filename,ciphertext_filename,key_provider', _generate_test_cases())
 def test_decrypt_from_file(plaintext_filename, ciphertext_filename, key_provider):
     """Tests decrypt from known good files."""

--- a/test/unit/test_aws_encryption_sdk.py
+++ b/test/unit/test_aws_encryption_sdk.py
@@ -14,10 +14,13 @@
 import unittest
 
 from mock import MagicMock, patch, sentinel
+import pytest
 import six
 
 import aws_encryption_sdk
 import aws_encryption_sdk.internal.defaults
+
+pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
 class TestAwsEncryptionSdk(unittest.TestCase):

--- a/test/unit/test_caches.py
+++ b/test/unit/test_caches.py
@@ -26,6 +26,8 @@ from aws_encryption_sdk.identifiers import Algorithm
 from aws_encryption_sdk.materials_managers import DecryptionMaterialsRequest, EncryptionMaterialsRequest
 from aws_encryption_sdk.structures import DataKey, MasterKeyInfo
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 VALUES = {
     'basic': {

--- a/test/unit/test_caches_base.py
+++ b/test/unit/test_caches_base.py
@@ -15,6 +15,8 @@ import pytest
 
 from aws_encryption_sdk.caches.base import CryptoMaterialsCache
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 def test_abstracts():
     with pytest.raises(TypeError) as excinfo:

--- a/test/unit/test_caches_crypto_cache_entry.py
+++ b/test/unit/test_caches_crypto_cache_entry.py
@@ -22,6 +22,8 @@ from aws_encryption_sdk.caches import (
 from aws_encryption_sdk.exceptions import NotSupportedError
 from aws_encryption_sdk.materials_managers import DecryptionMaterials, EncryptionMaterials
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 _VALID_KWARGS = {
     'CryptoMaterialsCacheEntryHints': dict(lifetime=5.0),
     'CryptoMaterialsCacheEntry': dict(

--- a/test/unit/test_caches_local.py
+++ b/test/unit/test_caches_local.py
@@ -22,6 +22,8 @@ import aws_encryption_sdk.caches.local
 from aws_encryption_sdk.caches.local import _OPPORTUNISTIC_EVICTION_ROUNDS, LocalCryptoMaterialsCache
 from aws_encryption_sdk.exceptions import CacheKeyError, NotSupportedError
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 def build_lcmc(**custom_kwargs):
     kwargs = dict(capacity=10)

--- a/test/unit/test_caches_null.py
+++ b/test/unit/test_caches_null.py
@@ -19,6 +19,8 @@ from aws_encryption_sdk.caches.null import NullCryptoMaterialsCache
 from aws_encryption_sdk.exceptions import CacheKeyError
 from aws_encryption_sdk.materials_managers import DecryptionMaterials, EncryptionMaterials
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 def test_put_encryption_materials():
     cache_key = b'ex_cache_key'

--- a/test/unit/test_crypto_authentication_signer.py
+++ b/test/unit/test_crypto_authentication_signer.py
@@ -20,6 +20,8 @@ from aws_encryption_sdk.internal.crypto.authentication import Signer
 from aws_encryption_sdk.internal.defaults import ALGORITHM
 from .test_crypto import VALUES
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.yield_fixture
 def patch_default_backend(mocker):

--- a/test/unit/test_crypto_authentication_verifier.py
+++ b/test/unit/test_crypto_authentication_verifier.py
@@ -20,6 +20,8 @@ from aws_encryption_sdk.internal.crypto.authentication import Verifier
 from aws_encryption_sdk.internal.defaults import ALGORITHM
 from .test_crypto import VALUES
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.yield_fixture
 def patch_default_backend(mocker):

--- a/test/unit/test_crypto_data_keys.py
+++ b/test/unit/test_crypto_data_keys.py
@@ -18,6 +18,8 @@ from pytest_mock import mocker  # noqa pylint: disable=unused-import
 import aws_encryption_sdk.internal.crypto.data_keys
 from aws_encryption_sdk.internal.crypto.data_keys import derive_data_encryption_key
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.yield_fixture
 def patch_default_backend(mocker):

--- a/test/unit/test_crypto_elliptic_curve.py
+++ b/test/unit/test_crypto_elliptic_curve.py
@@ -28,6 +28,8 @@ from aws_encryption_sdk.internal.crypto.elliptic_curve import (
 )
 from .test_crypto import VALUES
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.yield_fixture
 def patch_default_backend(mocker):

--- a/test/unit/test_crypto_encryption_decryptor.py
+++ b/test/unit/test_crypto_encryption_decryptor.py
@@ -18,6 +18,8 @@ from pytest_mock import mocker  # noqa pylint: disable=unused-import
 import aws_encryption_sdk.internal.crypto.encryption
 from aws_encryption_sdk.internal.crypto.encryption import decrypt, Decryptor
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.yield_fixture
 def patch_default_backend(mocker):

--- a/test/unit/test_crypto_encryption_encryptor.py
+++ b/test/unit/test_crypto_encryption_encryptor.py
@@ -19,6 +19,8 @@ import aws_encryption_sdk.internal.crypto.encryption
 from aws_encryption_sdk.internal.crypto.encryption import encrypt, Encryptor
 from aws_encryption_sdk.internal.structures import EncryptedData
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.yield_fixture
 def patch_default_backend(mocker):

--- a/test/unit/test_crypto_prehashing_authenticator.py
+++ b/test/unit/test_crypto_prehashing_authenticator.py
@@ -20,6 +20,8 @@ from aws_encryption_sdk.exceptions import NotSupportedError
 import aws_encryption_sdk.internal.crypto.authentication
 from aws_encryption_sdk.internal.crypto.authentication import _PrehashingAuthenticator
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.yield_fixture
 def patch_set_signature_type(mocker):

--- a/test/unit/test_crypto_wrapping_keys.py
+++ b/test/unit/test_crypto_wrapping_keys.py
@@ -22,6 +22,8 @@ from aws_encryption_sdk.internal.crypto.wrapping_keys import WrappingKey
 from aws_encryption_sdk.internal.structures import EncryptedData
 from .test_crypto import VALUES
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.yield_fixture
 def patch_default_backend(mocker):

--- a/test/unit/test_defaults.py
+++ b/test/unit/test_defaults.py
@@ -13,7 +13,11 @@
 """Test suite to verify calculated values in aws_encryption_sdk.internal.defaults"""
 import unittest
 
+import pytest
+
 import aws_encryption_sdk.internal.defaults
+
+pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
 class TestDefaults(unittest.TestCase):

--- a/test/unit/test_deserialize.py
+++ b/test/unit/test_deserialize.py
@@ -16,6 +16,7 @@ import unittest
 
 from cryptography.exceptions import InvalidTag
 from mock import MagicMock, patch, sentinel
+import pytest
 import six
 
 from aws_encryption_sdk.exceptions import NotSupportedError, SerializationError, UnknownIdentityError
@@ -23,6 +24,8 @@ from aws_encryption_sdk.identifiers import Algorithm
 import aws_encryption_sdk.internal.formatting.deserialize
 from aws_encryption_sdk.internal.structures import EncryptedData
 from .test_values import VALUES
+
+pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
 class TestDeserialize(unittest.TestCase):

--- a/test/unit/test_encryption_context.py
+++ b/test/unit/test_encryption_context.py
@@ -13,6 +13,7 @@
 """Unit test suite for aws_encryption_sdk.internal.formatting.encryption_context"""
 import unittest
 
+import pytest
 import six
 
 from aws_encryption_sdk.exceptions import SerializationError
@@ -20,6 +21,8 @@ from aws_encryption_sdk.identifiers import ContentAADString
 import aws_encryption_sdk.internal.defaults
 import aws_encryption_sdk.internal.formatting.encryption_context
 from .test_values import VALUES
+
+pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
 class TestEncryptionContext(unittest.TestCase):

--- a/test/unit/test_identifiers.py
+++ b/test/unit/test_identifiers.py
@@ -17,6 +17,8 @@ import pytest
 from aws_encryption_sdk.exceptions import InvalidAlgorithmError
 from aws_encryption_sdk.identifiers import Algorithm, EncryptionSuite, KDFSuite
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.mark.parametrize('check_algorithm, safe_to_cache', (
     (Algorithm.AES_128_GCM_IV12_TAG16, False),

--- a/test/unit/test_internal_structures.py
+++ b/test/unit/test_internal_structures.py
@@ -18,6 +18,8 @@ from aws_encryption_sdk.internal.structures import (
 )
 from .unit_test_utils import all_invalid_kwargs, all_valid_kwargs
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 VALID_KWARGS = {
     EncryptedData: [

--- a/test/unit/test_material_managers.py
+++ b/test/unit/test_material_managers.py
@@ -23,6 +23,8 @@ from aws_encryption_sdk.materials_managers import (
 )
 from aws_encryption_sdk.structures import DataKey
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 _VALID_KWARGS = {
     'EncryptionMaterialsRequest': dict(

--- a/test/unit/test_material_managers_base.py
+++ b/test/unit/test_material_managers_base.py
@@ -15,6 +15,8 @@ import pytest
 
 from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 def test_abstracts():
     with pytest.raises(TypeError) as excinfo:

--- a/test/unit/test_material_managers_caching.py
+++ b/test/unit/test_material_managers_caching.py
@@ -24,6 +24,8 @@ from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager
 import aws_encryption_sdk.materials_managers.caching
 from aws_encryption_sdk.materials_managers.caching import CachingCryptoMaterialsManager
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 def build_ccmm(**custom_kwargs):
     kwargs = dict(

--- a/test/unit/test_material_managers_default.py
+++ b/test/unit/test_material_managers_default.py
@@ -25,6 +25,8 @@ import aws_encryption_sdk.materials_managers.default
 from aws_encryption_sdk.materials_managers.default import DefaultCryptoMaterialsManager
 from aws_encryption_sdk.structures import DataKey
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.fixture
 def patch_for_dcmm_encrypt(mocker):

--- a/test/unit/test_providers_base_master_key.py
+++ b/test/unit/test_providers_base_master_key.py
@@ -24,6 +24,8 @@ from aws_encryption_sdk.key_providers.base import MasterKey, MasterKeyConfig, Ma
 from aws_encryption_sdk.structures import MasterKeyInfo
 from .test_values import VALUES
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @attr.s(hash=True)
 class MockMasterKeyConfig(MasterKeyConfig):

--- a/test/unit/test_providers_base_master_key_config.py
+++ b/test/unit/test_providers_base_master_key_config.py
@@ -16,6 +16,8 @@ import pytest
 from aws_encryption_sdk.key_providers.base import MasterKeyConfig
 from .unit_test_utils import all_invalid_kwargs, all_valid_kwargs
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 class FakeMasterKeyConfig(MasterKeyConfig):
     provider_id = None

--- a/test/unit/test_providers_base_master_key_provider.py
+++ b/test/unit/test_providers_base_master_key_provider.py
@@ -15,6 +15,7 @@ import unittest
 
 import attr
 from mock import call, MagicMock, patch, PropertyMock, sentinel
+import pytest
 import six
 
 from aws_encryption_sdk.exceptions import (
@@ -22,6 +23,8 @@ from aws_encryption_sdk.exceptions import (
 )
 from aws_encryption_sdk.key_providers.base import MasterKeyProvider, MasterKeyProviderConfig
 from .test_values import VALUES
+
+pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
 @attr.s(hash=True)

--- a/test/unit/test_providers_kms_master_key.py
+++ b/test/unit/test_providers_kms_master_key.py
@@ -16,6 +16,7 @@ import unittest
 import botocore.client
 from botocore.exceptions import ClientError
 from mock import MagicMock, patch, sentinel
+import pytest
 import six
 
 from aws_encryption_sdk.exceptions import DecryptKeyError, EncryptKeyError, GenerateKeyError
@@ -24,6 +25,8 @@ from aws_encryption_sdk.key_providers.base import MasterKey
 from aws_encryption_sdk.key_providers.kms import KMSMasterKey, KMSMasterKeyConfig
 from aws_encryption_sdk.structures import DataKey, EncryptedDataKey, MasterKeyInfo
 from .test_values import VALUES
+
+pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
 class TestKMSMasterKey(unittest.TestCase):

--- a/test/unit/test_providers_kms_master_key_config.py
+++ b/test/unit/test_providers_kms_master_key_config.py
@@ -18,6 +18,8 @@ from aws_encryption_sdk.key_providers.base import MasterKeyConfig
 from aws_encryption_sdk.key_providers.kms import _PROVIDER_ID, KMSMasterKeyConfig
 from .unit_test_utils import all_invalid_kwargs, all_valid_kwargs
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 VALID_KWARGS = {
     KMSMasterKeyConfig: [

--- a/test/unit/test_providers_kms_master_key_provider.py
+++ b/test/unit/test_providers_kms_master_key_provider.py
@@ -15,11 +15,14 @@ import unittest
 
 import botocore.client
 from mock import ANY, call, MagicMock, patch, sentinel
+import pytest
 import six
 
 from aws_encryption_sdk.exceptions import UnknownRegionError
 from aws_encryption_sdk.key_providers.base import MasterKeyProvider
 from aws_encryption_sdk.key_providers.kms import KMSMasterKey, KMSMasterKeyProvider
+
+pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
 class TestKMSMasterKeyProvider(unittest.TestCase):

--- a/test/unit/test_providers_kms_master_key_provider_config.py
+++ b/test/unit/test_providers_kms_master_key_provider_config.py
@@ -18,6 +18,8 @@ from aws_encryption_sdk.key_providers.base import MasterKeyProviderConfig
 from aws_encryption_sdk.key_providers.kms import KMSMasterKeyProviderConfig
 from .unit_test_utils import all_invalid_kwargs, all_valid_kwargs
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 VALID_KWARGS = {
     KMSMasterKeyProviderConfig: [

--- a/test/unit/test_providers_raw_master_key.py
+++ b/test/unit/test_providers_raw_master_key.py
@@ -14,6 +14,7 @@
 import unittest
 
 from mock import MagicMock, patch, sentinel
+import pytest
 
 from aws_encryption_sdk.identifiers import Algorithm, WrappingAlgorithm
 from aws_encryption_sdk.internal.crypto.wrapping_keys import WrappingKey
@@ -21,6 +22,8 @@ from aws_encryption_sdk.key_providers.base import MasterKey
 from aws_encryption_sdk.key_providers.raw import RawMasterKey, RawMasterKeyConfig
 from aws_encryption_sdk.structures import DataKey, EncryptedDataKey, MasterKeyInfo, RawDataKey
 from .test_values import VALUES
+
+pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
 class TestRawMasterKey(unittest.TestCase):

--- a/test/unit/test_providers_raw_master_key_config.py
+++ b/test/unit/test_providers_raw_master_key_config.py
@@ -20,6 +20,8 @@ from aws_encryption_sdk.key_providers.base import MasterKeyConfig
 from aws_encryption_sdk.key_providers.raw import RawMasterKeyConfig
 from .unit_test_utils import all_invalid_kwargs, all_valid_kwargs
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 STATIC_WRAPPING_KEY = WrappingKey(
     wrapping_algorithm=WrappingAlgorithm.AES_256_GCM_IV12_TAG16_NO_PADDING,
     wrapping_key=b'_________a symmetric key________',

--- a/test/unit/test_providers_raw_master_key_provider.py
+++ b/test/unit/test_providers_raw_master_key_provider.py
@@ -15,11 +15,14 @@ import unittest
 
 import attr
 from mock import MagicMock, patch, sentinel
+import pytest
 import six
 
 from aws_encryption_sdk.key_providers.base import MasterKeyProvider, MasterKeyProviderConfig
 from aws_encryption_sdk.key_providers.raw import RawMasterKeyProvider
 from .test_values import VALUES
+
+pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
 _MOCK_RAW_MASTER_KEY = MagicMock()

--- a/test/unit/test_serialize.py
+++ b/test/unit/test_serialize.py
@@ -24,6 +24,8 @@ from aws_encryption_sdk.internal.structures import EncryptedData
 from aws_encryption_sdk.structures import EncryptedDataKey, MasterKeyInfo
 from .test_values import VALUES
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.mark.parametrize('sequence_number, error_message', (
     (-1, r'Frame sequence number must be greater than 0'),

--- a/test/unit/test_streaming_client_configs.py
+++ b/test/unit/test_streaming_client_configs.py
@@ -23,6 +23,8 @@ from aws_encryption_sdk.materials_managers.default import DefaultCryptoMaterials
 from aws_encryption_sdk.streaming_client import _ClientConfig, DecryptorConfig, EncryptorConfig
 from .unit_test_utils import all_invalid_kwargs, all_valid_kwargs, build_valid_kwargs_list
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 class FakeCryptoMaterialsManager(CryptoMaterialsManager):
 

--- a/test/unit/test_streaming_client_encryption_stream.py
+++ b/test/unit/test_streaming_client_encryption_stream.py
@@ -16,6 +16,7 @@ import unittest
 
 import attr
 from mock import call, MagicMock, patch, PropertyMock, sentinel
+import pytest
 import six
 
 import aws_encryption_sdk.exceptions
@@ -23,6 +24,8 @@ from aws_encryption_sdk.internal.defaults import LINE_LENGTH
 from aws_encryption_sdk.key_providers.base import MasterKeyProvider
 from aws_encryption_sdk.streaming_client import _ClientConfig, _EncryptionStream
 from .test_values import VALUES
+
+pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
 @attr.s

--- a/test/unit/test_streaming_client_stream_decryptor.py
+++ b/test/unit/test_streaming_client_stream_decryptor.py
@@ -15,6 +15,7 @@ import io
 import unittest
 
 from mock import call, MagicMock, patch, sentinel
+import pytest
 import six
 
 from aws_encryption_sdk.exceptions import CustomMaximumValueExceeded, NotSupportedError, SerializationError
@@ -23,6 +24,8 @@ from aws_encryption_sdk.key_providers.base import MasterKeyProvider
 from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager
 from aws_encryption_sdk.streaming_client import StreamDecryptor
 from .test_values import VALUES
+
+pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
 class TestStreamDecryptor(unittest.TestCase):

--- a/test/unit/test_streaming_client_stream_encryptor.py
+++ b/test/unit/test_streaming_client_stream_encryptor.py
@@ -15,6 +15,7 @@ import io
 import unittest
 
 from mock import call, MagicMock, patch, sentinel
+import pytest
 import six
 
 from aws_encryption_sdk.exceptions import (
@@ -27,6 +28,8 @@ from aws_encryption_sdk.materials_managers.base import CryptoMaterialsManager
 from aws_encryption_sdk.streaming_client import StreamEncryptor
 from aws_encryption_sdk.structures import MessageHeader
 from .test_values import VALUES
+
+pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
 class TestStreamEncryptor(unittest.TestCase):

--- a/test/unit/test_structures.py
+++ b/test/unit/test_structures.py
@@ -21,6 +21,8 @@ from aws_encryption_sdk.structures import (
 )
 from .unit_test_utils import all_invalid_kwargs, all_valid_kwargs
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 VALID_KWARGS = {
     MessageHeader: [dict(

--- a/test/unit/test_util_str_ops.py
+++ b/test/unit/test_util_str_ops.py
@@ -15,7 +15,11 @@
 import codecs
 import unittest
 
+import pytest
+
 import aws_encryption_sdk.internal.str_ops
+
+pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
 class TestStrOps(unittest.TestCase):

--- a/test/unit/test_util_streams.py
+++ b/test/unit/test_util_streams.py
@@ -18,6 +18,8 @@ import pytest
 from aws_encryption_sdk.exceptions import ActionNotAllowedError
 from aws_encryption_sdk.internal.utils.streams import ROStream, TeeStream
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 def data():
     return io.BytesIO(b'asdijfhoaisjdfoiasjdfoijawef')

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -24,6 +24,8 @@ import aws_encryption_sdk.internal.utils
 from aws_encryption_sdk.structures import DataKey, EncryptedDataKey, MasterKeyInfo, RawDataKey
 from .test_values import VALUES
 
+pytestmark = [pytest.mark.unit, pytest.mark.local]
+
 
 @pytest.mark.parametrize('user_agent, suffix, output', (
     (None, 'test_suffix', 'test_suffix'),

--- a/tox.ini
+++ b/tox.ini
@@ -37,13 +37,6 @@ commands =
     all: pytest --cov aws_encryption_sdk -l {posargs}
     examples: pytest --cov examples/test/ -m examples -l {posargs}
 
-# Examples
-[testenv:examples]
-basepython = python3
-commands =
-    coverage run -m pytest \
-        examples/test/
-
 # Linters
 [testenv:flake8]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,7 @@
 envlist =
     py{27,34,35,36}-{local,integ,accept,examples},
     bandit, doc8, readme, docs,
-    flake8, pylint,
-    flake8-tests, pylint-tests,
-    flake8-examples, pylint-examples
+    {flake8,pylint}{,-tests,-examples}
 
 # Additional test environments:
 # vulture :: Runs vulture. Prone to false-positives.

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 envlist =
-    py{27,34,35,36},
+    py{27,34,35,36}-{local,integ,accept,examples},
     bandit, doc8, readme, docs,
     flake8, pylint,
     flake8-tests, pylint-tests,
-    examples,
     flake8-examples, pylint-examples
 
 # Additional test environments:
@@ -21,12 +20,7 @@ envlist =
 # release :: Builds dist files and uploads to pypi pypirc profile.
 
 [testenv]
-# _TEST_CONTROL : 
-# _AWS_KMS_KEY_ID : 
-# AWS_ACCESS/SECRET/TOKEN : 
 passenv =
-    # Enables or disables integration tests ('RUN' enables)
-    AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_CONTROL \
     # Identifies AWS KMS key id to use in integration tests
     AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID \
     # Pass through AWS credentials
@@ -39,9 +33,11 @@ deps =
     pytest-mock
     coverage
 commands =
-    coverage run -m pytest \
-        --cov aws_encryption_sdk \
-        {posargs}
+    local: pytest --cov aws_encryption_sdk -m local -l {posargs}
+    integ: pytest --cov aws_encryption_sdk -m integ -l {posargs}
+    accept: pytest --cov aws_encryption_sdk -m accept -l {posargs}
+    all: pytest --cov aws_encryption_sdk -l {posargs}
+    examples: pytest --cov examples/test/ -m examples -l {posargs}
 
 # Examples
 [testenv:examples]


### PR DESCRIPTION
This change moves our test selection logic from using environment variables to filter out tests run in a large batch to instead using pytest markers to select specific tests. In addition to being simpler to maintain, this both allows each test environment to run fewer tests and makes it much clearer in our CI which types of tests fail (ex: if credentials are not found, only integration, acceptance, and examples tests will fail).

This adds six markers:
1. local: superset of unit and functional (does not require network access)
1. unit: mark test as a unit test (does not require network access)
1. functional: mark test as a functional test (does not require network access)
1. integ: mark a test as an integration test (requires network access)
1. accept: mark a test as an acceptance test (requires network access)
1. examples: mark a test as an examples test (requires network access)

Validating that all tests are caught, the counts for tests run and skipped when filtering for each marker:

| marker     | run  | skipped | total |
|------------|------|---------|-------|
| all        | 2151 | 0       | 2151  |
| local      | 861  | 1290    | 2151  |
| unit       | 598  | 1553    | 2151  |
| functional | 263  | 1888    | 2151  |
| integ      | 26   | 2125    | 2151  |
| accept     | 1260 | 891     | 2151  |
| examples   | 4    | 2147    | 2151  |

```
local = unit + functional
861   = 598  + 263

all  = local + integ + accept + examples
2151 = 861   + 26    + 1260   + 4
```