### PR TITLE
adding AppVeyor build configuration and badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,9 @@ aws-encryption-sdk
 .. image:: https://travis-ci.org/awslabs/aws-encryption-sdk-python.svg?branch=master
    :target: https://travis-ci.org/awslabs/aws-encryption-sdk-python
 
+.. image:: https://ci.appveyor.com/api/projects/status/v42snaej4lavd5lm/branch/master?svg=true
+   :target: https://ci.appveyor.com/project/mattsb42-aws/aws-encryption-sdk-python-m2mgl
+
 The AWS Encryption SDK for Python provides a fully compliant, native Python implementation of the `AWS Encryption SDK`_.
 
 The latest full documentation can be found at `Read the Docs`_.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,95 @@
+# https://packaging.python.org/guides/supporting-windows-using-appveyor/
+
+environment:
+
+  matrix:
+    # The only test we perform on Windows are our actual code tests. All linting, static
+    # analysis, etc are only run on Linux (via Travis CI).
+
+    # Python 2.7
+    - PYTHON: "C:\\Python27"
+      TOXENV: "py27-local"
+    - PYTHON: "C:\\Python27"
+      TOXENV: "py27-integ"
+    - PYTHON: "C:\\Python27"
+      TOXENV: "py27-accept"
+    - PYTHON: "C:\\Python27"
+      TOXENV: "py27-examples"
+    - PYTHON: "C:\\Python27-x64"
+      TOXENV: "py27-local"
+    - PYTHON: "C:\\Python27-x64"
+      TOXENV: "py27-integ"
+    - PYTHON: "C:\\Python27-x64"
+      TOXENV: "py27-accept"
+    - PYTHON: "C:\\Python27-x64"
+      TOXENV: "py27-examples"
+
+    # Python 3.4
+    - PYTHON: "C:\\Python34"
+      TOXENV: "py34-local"
+    - PYTHON: "C:\\Python34"
+      TOXENV: "py34-integ"
+    - PYTHON: "C:\\Python34"
+      TOXENV: "py34-accept"
+    - PYTHON: "C:\\Python34"
+      TOXENV: "py34-examples"
+    - PYTHON: "C:\\Python34-x64"
+      DISTUTILS_USE_SDK: "1"
+      TOXENV: "py34-local"
+    - PYTHON: "C:\\Python34-x64"
+      DISTUTILS_USE_SDK: "1"
+      TOXENV: "py34-integ"
+    - PYTHON: "C:\\Python34-x64"
+      DISTUTILS_USE_SDK: "1"
+      TOXENV: "py34-accept"
+    - PYTHON: "C:\\Python34-x64"
+      DISTUTILS_USE_SDK: "1"
+      TOXENV: "py34-examples"
+
+    # Python 3.5
+    - PYTHON: "C:\\Python35"
+      TOXENV: "py35-local"
+    - PYTHON: "C:\\Python35"
+      TOXENV: "py35-integ"
+    - PYTHON: "C:\\Python35"
+      TOXENV: "py35-accept"
+    - PYTHON: "C:\\Python35"
+      TOXENV: "py35-examples"
+    - PYTHON: "C:\\Python35-x64"
+      TOXENV: "py35-local"
+    - PYTHON: "C:\\Python35-x64"
+      TOXENV: "py35-integ"
+    - PYTHON: "C:\\Python35-x64"
+      TOXENV: "py35-accept"
+    - PYTHON: "C:\\Python35-x64"
+      TOXENV: "py35-examples"
+
+    # Python 3.6
+    - PYTHON: "C:\\Python36"
+      TOXENV: "py36-local"
+    - PYTHON: "C:\\Python36"
+      TOXENV: "py36-integ"
+    - PYTHON: "C:\\Python36"
+      TOXENV: "py36-accept"
+    - PYTHON: "C:\\Python36"
+      TOXENV: "py36-examples"
+    - PYTHON: "C:\\Python36-x64"
+      TOXENV: "py36-local"
+    - PYTHON: "C:\\Python36-x64"
+      TOXENV: "py36-integ"
+    - PYTHON: "C:\\Python36-x64"
+      TOXENV: "py36-accept"
+    - PYTHON: "C:\\Python36-x64"
+      TOXENV: "py36-examples"
+
+install:
+  # Prepend newly installed Python to the PATH of this build
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  # Check the Python version to verify the correct version was installed
+  - "python --version"
+  - "python -m pip install wheel tox"
+
+build: off
+
+test_script:
+  - "tox"

--- a/examples/test/test_i_basic_file_encryption_with_multiple_providers.py
+++ b/examples/test/test_i_basic_file_encryption_with_multiple_providers.py
@@ -30,7 +30,7 @@ pytestmark = [pytest.mark.examples]
 
 def test_cycle_file():
     cmk_arn = get_cmk_arn()
-    _handle, filename = tempfile.mkstemp()
+    handle, filename = tempfile.mkstemp()
     with open(filename, 'wb') as f:
         f.write(os.urandom(1024))
     try:
@@ -42,4 +42,5 @@ def test_cycle_file():
         for f in new_files:
             os.remove(f)
     finally:
+        os.close(handle)
         os.remove(filename)

--- a/examples/test/test_i_basic_file_encryption_with_raw_key_provider.py
+++ b/examples/test/test_i_basic_file_encryption_with_raw_key_provider.py
@@ -27,7 +27,7 @@ pytestmark = [pytest.mark.examples]
 
 
 def test_cycle_file():
-    _handle, filename = tempfile.mkstemp()
+    handle, filename = tempfile.mkstemp()
     with open(filename, 'wb') as f:
         f.write(os.urandom(1024))
     try:
@@ -35,4 +35,5 @@ def test_cycle_file():
         for f in new_files:
             os.remove(f)
     finally:
+        os.close(handle)
         os.remove(filename)


### PR DESCRIPTION
Adding AppVeyor build configuration and badge #20 . Also fixes a minor issue with some of the examples tests that broke when run on Windows.

The AppVeyor project for this repo is set up[1], but because we can't use the OAuth integration it won't actually build properly until the `appveyor.yml` file is in this `master` branch. Here's the build on my fork[2].

[1] https://ci.appveyor.com/project/mattsb42-aws/aws-encryption-sdk-python-m2mgl
[2] https://ci.appveyor.com/project/mattsb42-aws/aws-encryption-sdk-python/build/1.0.5