### PR TITLE
Fixing emergent issues identified and caused by static checker updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dist
 docs/build
 test/integration/test_values.conf
 .python-version
+.pytest_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,9 @@ matrix:
       env: TOXENV=py36-accept
     - python: 3.6
       env: TOXENV=py36-examples
-    - python: 3.6
-      env: TOXENV=bandit
+# disabling Bandit run in Travis pending resolution of https://bugs.launchpad.net/bandit/+bug/1749603
+#    - python: 3.6
+#      env: TOXENV=bandit
     - python: 3.6
       env: TOXENV=doc8
     - python: 3.6

--- a/examples/src/basic_encryption.py
+++ b/examples/src/basic_encryption.py
@@ -11,8 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Example showing basic encryption and decryption of a value already in memory."""
-from __future__ import print_function
-
 import aws_encryption_sdk
 
 
@@ -35,7 +33,6 @@ def cycle_string(key_arn, source_plaintext, botocore_session=None):
         source=source_plaintext,
         key_provider=master_key_provider
     )
-    print('Ciphertext: ', ciphertext)
 
     # Decrypt the ciphertext
     cycled_plaintext, decrypted_header = aws_encryption_sdk.decrypt(
@@ -55,5 +52,3 @@ def cycle_string(key_arn, source_plaintext, botocore_session=None):
         pair in decrypted_header.encryption_context.items()
         for pair in encryptor_header.encryption_context.items()
     )
-
-    print('Decrypted: ', cycled_plaintext)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist =
     py{27,34,35,36}-{local,integ,accept,examples},
     bandit, doc8, readme, docs,
-    {flake8,pylint}{,-tests,-examples}
+    {flake8,pylint}{,-tests,-examples},
+    vulture
 
 # Additional test environments:
 # vulture :: Runs vulture. Prone to false-positives.
@@ -22,14 +23,15 @@ passenv =
     # Identifies AWS KMS key id to use in integration tests
     AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID \
     # Pass through AWS credentials
-    AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+    AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN \
+    # Pass through AWS profile name (useful for local testing)
+    AWS_PROFILE
 sitepackages = False
 deps =
     mock
     pytest>=3.3.1
     pytest-cov
     pytest-mock
-    coverage
 commands =
     local: pytest --cov aws_encryption_sdk -m local -l {posargs}
     integ: pytest --cov aws_encryption_sdk -m integ -l {posargs}
@@ -44,7 +46,8 @@ deps =
     flake8
     flake8-docstrings
     flake8-import-order
-    flake8-print>=3.0.1
+    # https://github.com/JBKahn/flake8-print/pull/30
+    flake8-print>=3.1.0
 commands =
     flake8 src/aws_encryption_sdk/ setup.py
 


### PR DESCRIPTION
## Bandit

Temporarily disabling Bandit runs in Travis CI due to bug in Bandit.
https://travis-ci.org/awslabs/aws-encryption-sdk-python/jobs/341659541
https://bugs.launchpad.net/bandit/+bug/1749603

## Print

Looks like `flake8-print` is working with the latest flake8 now, and it correctly identified that we had unnecessary print statements in one of our examples.

https://travis-ci.org/awslabs/aws-encryption-sdk-python/jobs/341659547