### PR TITLE
Make the experience running tests outside of tox friendlier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ matrix:
       env: TOXENV=py36-accept
     - python: 3.6
       env: TOXENV=py36-examples
+    - python: 3.6
+      env: TOXENV=nocmk
 # disabling Bandit run in Travis pending resolution of https://bugs.launchpad.net/bandit/+bug/1749603
 #    - python: 3.6
 #      env: TOXENV=bandit

--- a/test/integration/integration_test_utils.py
+++ b/test/integration/integration_test_utils.py
@@ -16,6 +16,7 @@ import os
 from aws_encryption_sdk.key_providers.kms import KMSMasterKeyProvider
 
 AWS_KMS_KEY_ID = 'AWS_ENCRYPTION_SDK_PYTHON_INTEGRATION_TEST_AWS_KMS_KEY_ID'
+_KMS_MKP = None
 
 
 def get_cmk_arn():
@@ -32,9 +33,17 @@ def get_cmk_arn():
     raise ValueError('KMS CMK ARN provided for integration tests much be a key not an alias')
 
 
-def setup_kms_master_key_provider():
+def setup_kms_master_key_provider(cache=True):
     """Reads the test_values config file and builds the requested KMS Master Key Provider."""
+    global _KMS_MKP  # pylint: disable=global-statement
+    if cache and _KMS_MKP is not None:
+        return _KMS_MKP
+
     cmk_arn = get_cmk_arn()
     kms_master_key_provider = KMSMasterKeyProvider()
     kms_master_key_provider.add_master_key(cmk_arn)
+
+    if cache:
+        _KMS_MKP = kms_master_key_provider
+
     return kms_master_key_provider

--- a/test/integration/test_i_xcompat_kms.py
+++ b/test/integration/test_i_xcompat_kms.py
@@ -34,7 +34,6 @@ except ImportError:
 
 
 def _generate_test_cases():
-    kms_key_provider = setup_kms_master_key_provider()
     try:
         root_dir = os.path.abspath(file_root())
     except Exception:  # pylint: disable=broad-except
@@ -65,15 +64,14 @@ def _generate_test_cases():
             if key['provider_id'] == 'aws-kms' and key['decryptable']:
                 _test_cases.append((
                     os.path.join(base_dir, test_case['plaintext']['filename']),
-                    os.path.join(base_dir, test_case['ciphertext']['filename']),
-                    kms_key_provider
+                    os.path.join(base_dir, test_case['ciphertext']['filename'])
                 ))
                 break
     return _test_cases
 
 
-@pytest.mark.parametrize('plaintext_filename,ciphertext_filename,key_provider', _generate_test_cases())
-def test_decrypt_from_file(plaintext_filename, ciphertext_filename, key_provider):
+@pytest.mark.parametrize('plaintext_filename, ciphertext_filename', _generate_test_cases())
+def test_decrypt_from_file(plaintext_filename, ciphertext_filename):
     """Tests decrypt from known good files."""
     with open(ciphertext_filename, 'rb') as infile:
         ciphertext = infile.read()
@@ -81,6 +79,6 @@ def test_decrypt_from_file(plaintext_filename, ciphertext_filename, key_provider
         plaintext = infile.read()
     decrypted_ciphertext, _header = aws_encryption_sdk.decrypt(
         source=ciphertext,
-        key_provider=key_provider
+        key_provider=setup_kms_master_key_provider()
     )
     assert decrypted_ciphertext == plaintext

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,4 @@
+mock
+pytest>=3.3.1
+pytest-cov
+pytest-mock

--- a/tox.ini
+++ b/tox.ini
@@ -27,11 +27,7 @@ passenv =
     # Pass through AWS profile name (useful for local testing)
     AWS_PROFILE
 sitepackages = False
-deps =
-    mock
-    pytest>=3.3.1
-    pytest-cov
-    pytest-mock
+deps = -rtest/requirements.txt
 commands =
     local: pytest --cov aws_encryption_sdk -m local -l {posargs}
     integ: pytest --cov aws_encryption_sdk -m integ -l {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36}-{local,integ,accept,examples},
+    py{27,34,35,36}-{local,integ,accept,examples}, nocmk,
     bandit, doc8, readme, docs,
     {flake8,pylint}{,-tests,-examples},
     vulture
@@ -18,6 +18,9 @@ envlist =
 # test-release :: Builds dist files and uploads to testpypi pypirc profile.
 # release :: Builds dist files and uploads to pypi pypirc profile.
 
+[testenv:base-command]
+commands = pytest --basetemp={envtmpdir} -l --cov aws_encryption_sdk {posargs}
+
 [testenv]
 passenv =
     # Identifies AWS KMS key id to use in integration tests
@@ -29,11 +32,18 @@ passenv =
 sitepackages = False
 deps = -rtest/requirements.txt
 commands =
-    local: pytest --cov aws_encryption_sdk -m local -l {posargs}
-    integ: pytest --cov aws_encryption_sdk -m integ -l {posargs}
-    accept: pytest --cov aws_encryption_sdk -m accept -l {posargs}
-    all: pytest --cov aws_encryption_sdk -l {posargs}
-    examples: pytest --cov examples/test/ -m examples -l {posargs}
+    local: {[testenv:base-command]commands} -m local
+    integ: {[testenv:base-command]commands} -m integ
+    accept: {[testenv:base-command]commands} -m accept
+    all: {[testenv:base-command]commands}
+    examples: {[testenv:base-command]commands} -m examples
+
+# Verify that local tests work without environment variables present
+[testenv:nocmk]
+basepython = python3
+sitepackages = False
+deps = -rtest/requirements.txt
+commands = {[testenv:base-command]commands} -m local
 
 # Linters
 [testenv:flake8]


### PR DESCRIPTION
Seeing this[1], I realized two things:

1. It is not currently very easy to run our tests outside of tox.
1. Some of our integration tests look for the CMK ARN environment variable during setup rather than execution. This can cause problems when attempting to run non-integ tests using pytest markers because the setup code is run whether you want those markers or not.

This change fixes both of these issues.

[1] https://github.com/pyca/cryptography/blob/master/Jenkinsfile#L151-L165