### PR TITLE
Partial fix (and actually test for) user agent modification

### DIFF
--- a/src/aws_encryption_sdk/identifiers.py
+++ b/src/aws_encryption_sdk/identifiers.py
@@ -22,7 +22,7 @@ from cryptography.hazmat.primitives.kdf import hkdf
 from aws_encryption_sdk.exceptions import InvalidAlgorithmError
 
 __version__ = '1.3.3'
-USER_AGENT_SUFFIX = 'AwsEncryptionSdkPython-KMSMasterKey/{}'.format(__version__)
+USER_AGENT_SUFFIX = 'AwsEncryptionSdkPython/{}'.format(__version__)
 
 
 class EncryptionSuite(Enum):

--- a/src/aws_encryption_sdk/internal/utils/__init__.py
+++ b/src/aws_encryption_sdk/internal/utils/__init__.py
@@ -165,19 +165,3 @@ def source_data_key_length_check(source_data_key, algorithm):
             actual=len(source_data_key.data_key),
             required=algorithm.kdf_input_len
         ))
-
-
-def extend_user_agent_suffix(user_agent, suffix):
-    """Adds a suffix to the provided user agent.
-
-    :param str user_agent: Existing user agent (None == not yet defined)
-    :param str suffix: Desired suffix to add to user agent
-    :returns: User agent with suffix
-    :rtype: str
-    """
-    if user_agent is None:
-        user_agent = ''
-    else:
-        user_agent += ' '
-    user_agent += suffix
-    return user_agent

--- a/test/integration/test_i_aws_encrytion_sdk_client.py
+++ b/test/integration/test_i_aws_encrytion_sdk_client.py
@@ -12,13 +12,14 @@
 # language governing permissions and limitations under the License.
 """Integration test suite for `aws_encryption_sdk`."""
 import io
+import logging
 import unittest
 
 import pytest
 
 import aws_encryption_sdk
-from aws_encryption_sdk.identifiers import Algorithm
-from .integration_test_utils import setup_kms_master_key_provider
+from aws_encryption_sdk.identifiers import Algorithm, USER_AGENT_SUFFIX
+from .integration_test_utils import setup_kms_master_key_provider, get_cmk_arn
 
 pytestmark = [pytest.mark.integ]
 
@@ -38,6 +39,16 @@ VALUES = {
         'key_c': 'value_c'
     }
 }
+
+
+def test_encrypt_verify_user_agent(caplog):
+    caplog.set_level(level=logging.DEBUG)
+    mkp = setup_kms_master_key_provider()
+    mk = mkp.master_key(get_cmk_arn())
+
+    mk.generate_data_key(algorithm=Algorithm.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384, encryption_context={})
+
+    assert USER_AGENT_SUFFIX in caplog.text
 
 
 class TestKMSThickClientIntegration(unittest.TestCase):

--- a/test/integration/test_i_aws_encrytion_sdk_client.py
+++ b/test/integration/test_i_aws_encrytion_sdk_client.py
@@ -20,7 +20,7 @@ import pytest
 import aws_encryption_sdk
 from aws_encryption_sdk.identifiers import Algorithm, USER_AGENT_SUFFIX
 from aws_encryption_sdk.key_providers.kms import KMSMasterKey
-from .integration_test_utils import setup_kms_master_key_provider, get_cmk_arn
+from .integration_test_utils import get_cmk_arn, setup_kms_master_key_provider
 
 pytestmark = [pytest.mark.integ]
 

--- a/test/integration/test_i_aws_encrytion_sdk_client.py
+++ b/test/integration/test_i_aws_encrytion_sdk_client.py
@@ -19,6 +19,7 @@ import pytest
 
 import aws_encryption_sdk
 from aws_encryption_sdk.identifiers import Algorithm, USER_AGENT_SUFFIX
+from aws_encryption_sdk.key_providers.kms import KMSMasterKey
 from .integration_test_utils import setup_kms_master_key_provider, get_cmk_arn
 
 pytestmark = [pytest.mark.integ]
@@ -41,10 +42,19 @@ VALUES = {
 }
 
 
-def test_encrypt_verify_user_agent(caplog):
+def test_encrypt_verify_user_agent_kms_master_key_provider(caplog):
     caplog.set_level(level=logging.DEBUG)
     mkp = setup_kms_master_key_provider()
     mk = mkp.master_key(get_cmk_arn())
+
+    mk.generate_data_key(algorithm=Algorithm.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384, encryption_context={})
+
+    assert USER_AGENT_SUFFIX in caplog.text
+
+
+def test_encrypt_verify_user_agent_kms_master_key(caplog):
+    caplog.set_level(level=logging.DEBUG)
+    mk = KMSMasterKey(key_id=get_cmk_arn())
 
     mk.generate_data_key(algorithm=Algorithm.AES_256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384, encryption_context={})
 

--- a/test/unit/test_providers_kms_master_key.py
+++ b/test/unit/test_providers_kms_master_key.py
@@ -20,7 +20,7 @@ import pytest
 import six
 
 from aws_encryption_sdk.exceptions import DecryptKeyError, EncryptKeyError, GenerateKeyError
-from aws_encryption_sdk.identifiers import Algorithm, USER_AGENT_SUFFIX
+from aws_encryption_sdk.identifiers import Algorithm
 from aws_encryption_sdk.key_providers.base import MasterKey
 from aws_encryption_sdk.key_providers.kms import KMSMasterKey, KMSMasterKeyConfig
 from aws_encryption_sdk.structures import DataKey, EncryptedDataKey, MasterKeyInfo

--- a/test/unit/test_providers_kms_master_key.py
+++ b/test/unit/test_providers_kms_master_key.py
@@ -96,16 +96,10 @@ class TestKMSMasterKey(unittest.TestCase):
         )
         assert test.grant_tokens is self.mock_grant_tokens
 
-    @patch('aws_encryption_sdk.key_providers.kms.extend_user_agent_suffix')
-    def test_init(self, patch_extend_user_agent_suffix):
+    def test_init(self):
         self.mock_client.meta.config.user_agent_extra = sentinel.user_agent_extra
         test = KMSMasterKey(config=self.mock_kms_mkc_1)
         assert test._key_id == VALUES['arn'].decode('utf-8')
-        patch_extend_user_agent_suffix.assert_called_once_with(
-            user_agent=sentinel.user_agent_extra,
-            suffix=USER_AGENT_SUFFIX
-        )
-        assert self.mock_client.meta.config.user_agent_extra == patch_extend_user_agent_suffix.return_value
 
     def test_generate_data_key(self):
         test = KMSMasterKey(config=self.mock_kms_mkc_3)

--- a/test/unit/test_providers_kms_master_key_provider.py
+++ b/test/unit/test_providers_kms_master_key_provider.py
@@ -99,7 +99,7 @@ class TestKMSMasterKeyProvider(unittest.TestCase):
             region_name='ex_region_name',
             botocore_session=ANY
         )
-        self.mock_boto3_session_instance.client.assert_called_once_with('kms')
+        self.mock_boto3_session_instance.client.assert_called_once_with('kms', config=test._user_agent_adding_config)
         assert test._regional_clients['ex_region_name'] is self.mock_boto3_client_instance
 
     def test_add_regional_client_exists(self):

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -27,15 +27,6 @@ from .test_values import VALUES
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 
-@pytest.mark.parametrize('user_agent, suffix, output', (
-    (None, 'test_suffix', 'test_suffix'),
-    ('test_existing_suffix', 'test_suffix', 'test_existing_suffix test_suffix')
-))
-def test_extend_user_agent_suffix(user_agent, suffix, output):
-    test = aws_encryption_sdk.internal.utils.extend_user_agent_suffix(user_agent, suffix)
-    assert test == output
-
-
 class TestUtils(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
*Issue #, if available:* #25

*Description of changes:*

* Simplify the user agent to just identify the client in general, not any specific MKP.
* Use the correct method of setting the user agent for new clients.
* Add default client building logic for `KMSMasterKey` to both simplify direct use of the class and make it more likely that any given client is using our user agent.
* Actually test to make sure that the user agent is really being modified.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
