### PR TITLE
1.3.4 version bump and changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,27 @@
 Changelog
 *********
 
-1.3.3
-=====
+1.3.4 -- 2018-04-12
+===================
+
+Bugfixes
+--------
+* AWS KMS master key/provider user agent extension fixed.
+  `#47 <https://github.com/awslabs/aws-encryption-sdk-python/pull/47>`_
+
+Maintenance
+-----------
+* New minimum pytest version 3.3.1 to avoid bugs in 3.3.0
+  `#32 <https://github.com/awslabs/aws-encryption-sdk-python/issues/32>`_
+* New minimum attrs version 17.4.0 to allow use of `converter` rather than `convert`
+  `#39 <https://github.com/awslabs/aws-encryption-sdk-python/issues/39>`_
+* Algorithm Suites are modeled as collections of sub-suites now
+  `#36 <https://github.com/awslabs/aws-encryption-sdk-python/pull/36>`_
+* Selecting test suites is more sane now, with pytest markers.
+  `#41 <https://github.com/awslabs/aws-encryption-sdk-python/pull/41>`_
+
+1.3.3 -- 2017-12-05
+===================
 
 Bugfixes
 --------
@@ -16,13 +35,13 @@ Maintenance
   `#32 <https://github.com/awslabs/aws-encryption-sdk-python/issues/32>`_
   `pytest-dev/pytest#2957 <https://github.com/pytest-dev/pytest/issues/2957>`_
 
-1.3.2
-=====
+1.3.2 -- 2017-09-28
+===================
 * Addressed `issue #13 <https://github.com/awslabs/aws-encryption-sdk-python/issues/13>`_
   to properly handle non-seekable source streams.
 
-1.3.1
-=====
+1.3.1 -- 2017-09-12
+===================
 
 Reorganization
 --------------
@@ -44,8 +63,8 @@ Maintenance
 * Addressed assorted linting issues to bring source, tests, examples, and docs up to configured
   linting standards.
 
-1.3.0
-=====
+1.3.0 -- 2017-08-04
+===================
 
 Major
 -----
@@ -65,12 +84,12 @@ Minor
 * Added support for calculating ciphertext message length from header
 * Migrated README from md to rst
 
-1.2.2
-=====
+1.2.2 -- 2017-05-23
+===================
 * Fixed ``attrs`` version to 16.3.0 to avoid `breaking changes in attrs 17.1.0`_
 
-1.2.0
-=====
+1.2.0 -- 2017-03-21
+===================
 * Initial public release
 
 .. _breaking changes in attrs 17.1.0: https://attrs.readthedocs.io/en/stable/changelog.html

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -39,8 +39,4 @@ Modules
     aws_encryption_sdk.internal.structures
     aws_encryption_sdk.internal.utils
 
-*********
-Changelog
-*********
-
 .. include:: ../CHANGELOG.rst

--- a/src/aws_encryption_sdk/identifiers.py
+++ b/src/aws_encryption_sdk/identifiers.py
@@ -21,7 +21,7 @@ from cryptography.hazmat.primitives.kdf import hkdf
 
 from aws_encryption_sdk.exceptions import InvalidAlgorithmError
 
-__version__ = '1.3.3'
+__version__ = '1.3.4'
 USER_AGENT_SUFFIX = 'AwsEncryptionSdkPython/{}'.format(__version__)
 
 


### PR DESCRIPTION
*Description of changes:*

* Version bump and changelog for v1.3.4
* Remove redundant title in docs index. The same title is in CHANGELOG.rst, so this created a double title: http://aws-encryption-sdk-python.readthedocs.io/en/latest/#changelog
* Add release dates for versions in changelog. This will make it easier for us to keep the changelog up to date as changes are made in between releases and make it clearer to readers whether we have actually released features yet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
